### PR TITLE
Add archon-memory-core to Products > Open-Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ _Ordered by the number of Github stars._
       [[pypi](https://pypi.org/project/widemem-ai/)]
       _Lightweight memory layer with importance scoring, temporal decay, 3-tier hierarchy, YMYL prioritization, and batch conflict resolution. Local-first with SQLite + FAISS._
 
+25. **[archon-memory-core](https://github.com/atw4757-byte/archon-memory-core)** ![Star](https://img.shields.io/github/stars/atw4757-byte/archon-memory-core.svg?style=social&label=Star)
+      [[code](https://github.com/atw4757-byte/archon-memory-core)]
+      [[pypi](https://pypi.org/project/archon-memory-core/)]
+      _Apache 2.0 memory library for LLM agents with supersede-aware consolidation, type-aware salience, and active forgetting. Resolves contradictory facts at retrieval time. AMB v2.3 benchmark: 99.2% top-1 over 90 simulated days. Local-first on ChromaDB + Ollama._
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
Adds [archon-memory-core](https://github.com/atw4757-byte/archon-memory-core) as entry #25 in Products > Open-Source.

**What it is:** Apache 2.0 Python memory library for LLM agents. `pip install archon-memory-core`, Python 3.10+. Local-first on ChromaDB + Ollama.

**Why this list:** Directly in scope — a memory mechanism for LLM agents focused on long-term context, retrieval, and contradiction resolution. Mechanism: supersede-aware consolidation + type-aware salience + active forgetting.

**Benchmark:** Agentic Memory Benchmark v2.3 (250 queries, 3 seeds, 90 simulated days) — 99.2% top-1 with consolidation, flat from day 7 to day 90. Without consolidation, same retriever collapses to 49.2%. Preregistered harness and raw results in the repo.

Placed at end of Open-Source list per the "ordered by GitHub stars" convention (newly published, low stars). Formatting matches entry #24 (widemem-ai): name + star badge + [[code]] + [[pypi]] + italic description.