### PR TITLE
Add Puppyone to Open-Source Products

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ _Ordered by the number of Github stars._
 28. **[archon-memory-core](https://github.com/atw4757-byte/archon-memory-core)** ![Star](https://img.shields.io/github/stars/atw4757-byte/archon-memory-core.svg?style=social&label=Star)
       [[code](https://github.com/atw4757-byte/archon-memory-core)]
 
+29. **[Puppyone](https://www.puppyone.ai)** ![Star](https://img.shields.io/github/stars/puppyone-ai/puppyone.svg?style=social&label=Star)
+      [[code](https://github.com/puppyone-ai/puppyone)]
+      [[docs](https://www.puppyone.ai/doc)]
+      _Structural agent memory as a file system: auto-versioned writes, per-agent ACLs (File Level Security), audit logs, 15+ data connectors. Native MCP / REST / CLI. Apache 2.0._
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
## What this adds

Adds [Puppyone](https://github.com/puppyone-ai/puppyone) to **💿 Products → Open-Source** as item #29 (following star-count ordering).

## What it is

Puppyone is **structural agent memory implemented as a file system** — distinct from the vector / embedding-based entries (Mem0, Zep) and the graph-based entries (Letta, Graphiti) in this list.

Where vector DBs solve semantic recall, Puppyone solves the persistent file workspace problem agents need across sessions and across instances:

- **Auto-versioning at the write boundary** — every agent edit is snapshotted automatically (no manual `git commit`), so cross-session memory recovery is trivial
- **Per-agent ACLs (File Level Security)** — different agents see different views of the same Context Space; isolation enforced at the storage layer, not the prompt
- **15+ OAuth connectors** — Notion / GitHub / Drive / Linear sync external sources as agent-readable files (write-time memory ingestion)
- **Multi-channel access** — same memory exposed via MCP, REST, CLI, and sandbox simultaneously

## Why it complements the existing list

The list already has excellent coverage of:
- Semantic / vector memory (Mem0, Letta, Zep)
- Graph memory (Graphiti, Omnigraph)
- Episodic memory (claude-mem)

Puppyone adds the **structural / filesystem-shaped memory** dimension — useful when an agent's memory is naturally hierarchical (folders, projects, multi-document context) rather than fact-based.

- Repo: https://github.com/puppyone-ai/puppyone
- Site: https://www.puppyone.ai
- Docs: https://www.puppyone.ai/doc
- License: Apache 2.0

Made with [Cursor](https://cursor.com)