### PR TITLE
feat: add Dakera to Open-Source Products section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ _Ordered by the number of Github stars._
 28. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
 
+29. **[Dakera](https://dakera.ai/)** ![Star](https://img.shields.io/github/stars/Dakera-AI/dakera-mcp.svg?style=social&label=Star)
+      [[code](https://github.com/Dakera-AI/dakera)]
+      [[mcp-server](https://github.com/Dakera-AI/dakera-mcp)]
+      _Production-grade AI agent memory server. 83 MCP tools for store, recall, hybrid BM25+vector search, knowledge graphs, and cross-agent memory sharing. Decay-weighted importance scoring. Built in Rust._
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
## Add Dakera

**Dakera** is a production-grade AI agent memory server built in Rust, with an MCP server providing 83 tools to any MCP-compatible agent framework.

- **Core repo:** https://github.com/Dakera-AI/dakera
- **MCP server:** https://github.com/Dakera-AI/dakera-mcp

**Key capabilities:**
- Decay-weighted importance scoring — memories fade naturally, most-relevant surfaces first
- Hybrid retrieval: BM25 full-text + ONNX vector embeddings
- Knowledge graph construction, entity extraction, cross-agent memory sharing
- Session-scoped memory isolation
- 83 MCP tools across 15 categories (memory, sessions, agents, knowledge, vectors, full-text)
- Self-hosted via Docker or `cargo install dakera-mcp`

**Benchmark:** Competitive on LoCoMo benchmark with ongoing Core Engine improvements.

Adding as item 29 in the Open-Source Products section, ordered after PackRat.