### PR TITLE
Add Dakera — benchmark-validated self-hosted MCP agent memory (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ _Ordered by the number of Github stars._
 28. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
 
+29. **[Dakera](https://dakera.ai/)** ![Star](https://img.shields.io/github/stars/dakera-ai/dakera-mcp.svg?style=social&label=Star)
+      [[code](https://github.com/dakera-ai/dakera-mcp)]
+      [[docs](https://docs.dakera.ai/)]
+    - Self-hosted agent memory server achieving **87.8% on LoCoMo**, the standard long-term conversational memory benchmark. Decay-weighted recall, hybrid BM25+HNSW retrieval, 83 MCP tools, and a knowledge graph layer — built in Rust with zero external LLM dependencies.
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
## Summary

Adding [Dakera](https://github.com/dakera-ai/dakera-mcp) as entry #29 in the **Open-Source** products section.

Dakera occupies a distinct position in this list: it's the only entry that combines MCP-native tooling (83 tools) with a published benchmark result on the LoCoMo evaluation, making it directly comparable to Mem0, Graphiti/Zep, and Letta on measurable memory quality.

**What differentiates Dakera:**
- **87.8% LoCoMo accuracy** — validated against the same benchmark that evaluates long-term conversational memory recall
- **MCP-native from the ground up** — 83 MCP tools; not a wrapper but a purpose-built MCP memory server
- **Decay-weighted retrieval** — importance scores degrade over time, surfacing fresher, more relevant memories
- **Self-hosted only** — no SaaS, no telemetry, runs on your hardware via Docker Compose
- **Zero LLM API dependencies** — classification, embedding, and retrieval all handled internally in Rust

Placed at #29 as it's a newer project (0 stars currently) but included for its benchmark credentials and unique technical positioning.