### PR TITLE
Add Tenure local llm memory proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ _Ordered by the number of Github stars._
 29. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
 
+30. **[Tenure](https://github.com/jeffreyflynt/tenure)** ![Star](https://img.shields.io/github/stars/jeffreyflynt/tenure.svg?style=social&label=Star)
+      [[code](https://github.com/jeffreyflynt/tenure)]
+      [[paper](https://arxiv.org/abs/2605.11325)]
+      _Privacy-first local proxy that gives any OpenAI-compatible LLM persistent, structured memory across sessions. No re-explaining your stack, decisions, or voice ever again._
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
Adds [Tenure](https://github.com/jeffreyflynt/tenure) to Open Source Products list with the code and paper. 

• Argues cross-session LLM memory is a state management problem, not a search problem, and introduces a typed belief schema with five belief types, epistemic status, versioned supersession, and a `why_it_matters` field that converts extracted facts into imperative instructions rather than declarative facts.<br>
• Demonstrates that cosine similarity over dense embeddings achieves mean precision of 0.12 on a 72-case retrieval suite, while alias-weighted BM25 with hard scope isolation achieves 1.0, passing 72/72 cases; under multi-turn topic drift, vector search produces drift scores of 0.43–0.50 on noise-critical turns while BM25 maintains 0.0.<br>
• Ships as a local-first OpenAI-compatible proxy that injects curated belief context into every LLM session transparently; includes a reusable 72-case benchmark covering alias resolution, scope disambiguation, supersession chain exclusion, and session-level noise isolation.