### PR TITLE
Add Akephalos to open-source memory products

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ _Ordered by the number of Github stars._
 29. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
 
+30. **[Akephalos](https://github.com/sunnja69/akephalos)** ![Star](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social&label=Star)
+      [[code](https://github.com/sunnja69/akephalos)]
+      _Local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and durable memories across Codex, Claude Code, Cursor, Hermes, OpenClaw, MCP clients, and machines via plain files/Git._
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
Adds Akephalos as an open-source agent memory/context project. Akephalos v0.1 is a local-first, markdown-first `.akephalos` passport for preferences, tool notes, rules, project context, and durable memories across agent/dev tools and machines, synced through plain files/Git.\n\nRepo: https://github.com/sunnja69/akephalos\nTag: v0.1.0