### PR TITLE
Add MisakaNet to Products (Open-Source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ _Ordered by the number of Github stars._
       [[code](https://github.com/sunnja69/akephalos)]
       _Local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and durable memories across Codex, Claude Code, Cursor, Hermes, OpenClaw, MCP clients, and machines via plain files/Git._
 
+34. **[MisakaNet](https://github.com/Ikalus1988/MisakaNet)** ![Star](https://img.shields.io/github/stars/Ikalus1988/MisakaNet.svg?style=social&label=Star)
+      [[code](https://github.com/Ikalus1988/MisakaNet)]
+      [[wiki](https://github.com/Ikalus1988/MisakaNet/wiki)]
+      _Git-based distributed swarm memory for AI agents. Cross-agent lesson sharing via GitHub Issues — when one agent solves a problem, every node on the network learns from it. 104+ shared lessons, 21+ registered nodes, supports Hermes/Claude/Codex/OpenClaw/OpenCode._
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
## What is MisakaNet?

[MisakaNet](https://github.com/Ikalus1988/MisakaNet) is a git-based distributed swarm memory for AI agents. It enables cross-agent lesson sharing via GitHub Issues — when one agent solves a problem, every node on the network learns from it.

### Why it fits here

- **Agent Memory**: Lessons are persistent, searchable knowledge stored as markdown files in git
- **Distributed**: 21+ registered nodes (Hermes, Claude, Codex, OpenClaw, OpenCode) share knowledge across the network
- **Git-native**: Uses GitHub Issues as message bus, Git for synchronization — zero infrastructure
- **104+ shared lessons** across 7 domains (RAG, DevOps, Feishu, Fanuc, Network, Claude, Hub)
- **Apache 2.0** license

### How it works

```
Agent A: hits bug → documents fix → pushes to shared lessons/
Agent B: hits same bug → searches lessons/ → finds fix → solves in seconds
```

This is the "distributed muscle memory" approach to agent memory — knowledge persists across sessions and propagates across nodes automatically.

## Changes

Added entry #34 to the Open-Source Products section, ordered by GitHub stars (20 stars, after Akephalos).