### PR TITLE
Add Origin to open-source products

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,23 +270,29 @@ _Ordered by the number of Github stars._
       [[wiki](https://github.com/Ikalus1988/MisakaNet/wiki)]
       _Git-based distributed swarm memory; agents share lessons across nodes via GitHub Issues._
 
-33. **[archon-memory-core](https://github.com/atw4757-byte/archon-memory-core)** 
+33. **[Origin](https://useorigin.app/)**
+      ![Star](https://img.shields.io/github/stars/7xuanlu/origin.svg?style=social&label=Star)
+      [[code](https://github.com/7xuanlu/origin)]
+      [[docs](https://useorigin.app/docs)]
+      _Local-first AI work memory for Claude Code, Cursor, Codex, and MCP clients, with session handoffs, source-backed wiki pages, graph context, and hybrid retrieval through one local daemon._
+
+34. **[archon-memory-core](https://github.com/atw4757-byte/archon-memory-core)** 
       ![Star](https://img.shields.io/github/stars/atw4757-byte/archon-memory-core.svg?style=social&label=Star)
       [[code](https://github.com/atw4757-byte/archon-memory-core)]
       _Local-first agent memory with nightly consolidation, active forgetting, and salience scoring._
 
-34. **[Synap](https://maximem.ai)** 
+35. **[Synap](https://maximem.ai)** 
       ![Star](https://img.shields.io/github/stars/maximem-ai/maximem_synap_sdk.svg?style=social&label=Star)
       [[code](https://github.com/maximem-ai/maximem_synap_sdk)]
       [[docs](https://docs.maximem.ai)]
       _Long-term memory layer that extracts facts, preferences, episodes, and temporal events from conversations; integrates with most major agent frameworks._
 
-35. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
+36. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
       ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
       _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
 
-36. **[Akephalos](https://github.com/sunnja69/akephalos)** 
+37. **[Akephalos](https://github.com/sunnja69/akephalos)** 
       ![Star](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social&label=Star)
       [[code](https://github.com/sunnja69/akephalos)]
       _Local-first, markdown-based portable agent profile (preferences, rules, durable memories) synced across agents via plain files and Git._


### PR DESCRIPTION
Adds Origin to the open-source Products section.\n\nOrigin is local-first AI work memory for Claude Code, Cursor, Codex, and MCP clients. It carries session handoffs, decisions, project context, source-backed wiki pages, graph context, and hybrid retrieval through one local daemon.\n\nVerification:\n- Matched the existing product-entry format.\n- Used the current Origin README positioning.\n- Placed near adjacent entries by current GitHub star count.