### PR TITLE
Add Agent Memory Techniques (30 runnable notebooks) to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ _Ordered by the number of Github stars._
      [[Part-B](https://www.dailydoseofds.com/ai-agents-crash-course-part-16-with-implementation/)]
      [[Part-C](https://www.dailydoseofds.com/ai-agents-crash-course-part-17-with-implementation/)]
 
+ - **Agent Memory Techniques** (NirDiamant): 30 runnable Jupyter notebooks covering conversation buffers, vector stores, knowledge graphs, episodic and semantic memory, Mem0, MemGPT/Letta, Zep, Graphiti, and LoCoMo benchmarks
+     [[code](https://github.com/NirDiamant/Agent_Memory_Techniques)]
+
 ---
 
 ## 📚 Surveys


### PR DESCRIPTION
Adds [Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques) to the Tutorials section — a free, open-source collection of 30 runnable Jupyter notebooks covering agent memory end to end: conversation buffers, sliding-window and summary memory, vector stores, knowledge graphs, episodic and semantic memory, Mem0, MemGPT/Letta, Zep, Graphiti, and LoCoMo benchmarks. Followed the existing 2025 Tutorials format. Happy to adjust placement or wording.