### PR TITLE
Add consciousness-server to Products / Open-Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ _Ordered by the number of Github stars._
       [[code](https://github.com/xiaofanliu525-ctrl/suyi-memory)]
       _Dual-temporal memory engine for AI agents — SQLite-backed, zero-dependency, Ebbinghaus-decayed fact storage with skill crystallization._
 
+41. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
+      ![Star](https://img.shields.io/github/stars/build-on-ai/consciousness-server.svg?style=social&label=Star)
+      [[code](https://github.com/build-on-ai/consciousness-server)]
+      _Self-hosted HTTP services that give multiple local agents one shared memory: notes, chat, tasks, semantic search, agent registry, and opt-in ed25519 auth. Runs fully local (embeddings via Ollama); nothing leaves the host._
+
 ### Closed-Source
 
 1. [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
Adds **[consciousness-server](https://github.com/build-on-ai/consciousness-server)** to **💿 Products → Open-Source** (disclosure: I'm a maintainer of the project).

It's a self-hosted ecosystem that gives multiple local agents one shared memory layer: notes/chat/tasks over plain HTTP, semantic search (local embeddings via Ollama), an agent registry, and opt-in ed25519 auth — all up with `docker compose up`. The angle that's a bit different from most entries here: memory is a property of the shared substrate the agents run on, not a per-agent library, so cross-agent memory and per-agent provenance come from the infrastructure itself. Fully local, AGPL-3.0.

Placed at the end of Open-Source (currently 0 stars, per the star ordering). Happy to adjust wording or placement.