### PR TITLE
Add taOSmd (local-first, benchmarked agent memory on a full transcript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,11 @@ _Ordered by the number of Github stars._
       ![Star](https://img.shields.io/github/stars/build-on-ai/consciousness-server.svg?style=social&label=Star)
       [[code](https://github.com/build-on-ai/consciousness-server)]
       _Self-hosted HTTP services that give multiple local agents one shared memory: notes, chat, tasks, semantic search, agent registry, and opt-in ed25519 auth. Runs fully local (embeddings via Ollama); nothing leaves the host._
+43. **[taOSmd](https://github.com/jaylfc/taosmd)**
+      ![Star](https://img.shields.io/github/stars/jaylfc/taosmd.svg?style=social&label=Star)
+      [[code](https://github.com/jaylfc/taosmd)]
+      [[benchmarks](https://github.com/jaylfc/taosmd/blob/master/docs/benchmarks.md)]
+      _Local-first, offline agent memory built on an append-only transcript (user + agent messages, tool calls and results, decisions, errors). A librarian derives a typed temporal knowledge graph from it; corrected facts supersede old ones via invalidation. Hybrid vector + BM25 retrieval, tuned for small local models (97% on LongMemEval-S, runs on an 8GB Pi)._
 
 ### Closed-Source
 


### PR DESCRIPTION
Adds **taOSmd** (https://github.com/jaylfc/taosmd), a local-first, offline agent memory system, to the list, following the existing entry format in this section.

What it is: an append-only, read-only transcript (user + agent messages, tool calls and results, decisions, errors) that a librarian derives a typed temporal knowledge graph and vector memory from. Corrected facts supersede old ones via invalidation (recall returns only the active fact). Hybrid vector + BM25 retrieval, tuned to run on small local models, fully offline (8GB RAM, no API keys). Benchmarked: 97.0% end-to-end Judge on LongMemEval-S and a same-tier leader result on LoCoMo (methodology in docs/benchmarks.md).

Open source (Python API + CLI today; MCP and a local HTTP API are work in progress). Happy to adjust placement, wording, or fields to match your conventions.