### PR TITLE
Add Agent Knowledge Cycle to Open-Source products

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,28 +324,34 @@ _Ordered by the number of Github stars._
       [[code](https://github.com/atw4757-byte/archon-memory-core)]
       _Local-first agent memory with nightly consolidation, active forgetting, and salience scoring._
 
-41. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
+41. **[Agent Knowledge Cycle](https://github.com/shimo4228/agent-knowledge-cycle)**
+      ![Star](https://img.shields.io/github/stars/shimo4228/agent-knowledge-cycle.svg?style=social&label=Star)
+      [[code](https://github.com/shimo4228/agent-knowledge-cycle)]
+      [[paper](https://doi.org/10.5281/zenodo.20578272)]
+      _Six-phase knowledge cycle specification (ADRs, JSON schemas, reference implementation) that turns coding-agent sessions into persistent skills, rules, and memory._
+
+42. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
       ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
       _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
 
-42. **[Agentic Task System](https://github.com/renezander030/agentic-task-system)**
+43. **[Agentic Task System](https://github.com/renezander030/agentic-task-system)**
       ![Star](https://img.shields.io/github/stars/renezander030/agentic-task-system.svg?style=social&label=Star)
       [[code](https://github.com/renezander030/agentic-task-system)]
       [[npm](https://www.npmjs.com/package/@reneza/ats-cli)]
       _Agent-native context layer over the task app you already use (TickTick today; Notion/Obsidian on the roadmap); hybrid retrieval (dense + sparse + keyword fused via RRF) over your tasks/notes, exposed to agents via a CLI with pluggable storage adapters._
 
-43. **[Akephalos](https://github.com/sunnja69/akephalos)** 
+44. **[Akephalos](https://github.com/sunnja69/akephalos)** 
       ![Star](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social&label=Star)
       [[code](https://github.com/sunnja69/akephalos)]
       _Local-first, markdown-based portable agent profile (preferences, rules, durable memories) synced across agents via plain files and Git._
 
-44. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
+45. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
       ![Star](https://img.shields.io/github/stars/xiaofanliu525-ctrl/suyi-memory.svg?style=social&label=Star)
       [[code](https://github.com/xiaofanliu525-ctrl/suyi-memory)]
       _Dual-temporal memory engine for AI agents — SQLite-backed, zero-dependency, Ebbinghaus-decayed fact storage with skill crystallization._
 
-45. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
+46. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
       ![Star](https://img.shields.io/github/stars/build-on-ai/consciousness-server.svg?style=social&label=Star)
       [[code](https://github.com/build-on-ai/consciousness-server)]
       _Self-hosted HTTP services that give multiple local agents one shared memory: notes, chat, tasks, semantic search, agent registry, and opt-in ed25519 auth. Runs fully local (embeddings via Ollama); nothing leaves the host._


### PR DESCRIPTION
Adds [Agent Knowledge Cycle](https://github.com/shimo4228/agent-knowledge-cycle) (AKC) to the Open-Source products section, positioned per current star count (3) between archon-memory-core and PackRat, with subsequent entries renumbered.

AKC is a six-phase knowledge cycle (research / extract / curate / promote / measure / maintain) that turns coding-agent sessions into persistent skills, rules, and memory — shipped as ADRs, JSON schemas, and a dependency-free Python reference implementation, DOI-archived on Zenodo ([10.5281/zenodo.19200726](https://doi.org/10.5281/zenodo.19200726)). The [[paper]] link points to the companion paper *Harness Alignment and Harness Drift* ([10.5281/zenodo.20578272](https://doi.org/10.5281/zenodo.20578272)).

Description follows the ≤25-word factual format from CONTRIBUTING.md. I am the author.