### PR TITLE
Add Agentage Memory (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,9 @@ _Ordered by the number of Github stars._
    [[partial-code](https://github.com/maxbaluev/accreted-intelligence)]
    _Local-first MCP Work Model for coding agents that retrieves scored memory, records actions, and credits real outcomes; engine is a closed-source binary._
 
+-  [agentage Memory](https://memory.agentage.io)
+   _Remote MCP memory server (OAuth 2.1 + PKCE + DCR) giving Claude, Cursor, and ChatGPT one shared markdown memory mirrored locally as files you own._
+
 ### Archival
 
 -  [MemPalace](https://github.com/MemPalace/mempalace) ❌ (Debunked)

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ _Ordered by the number of Github stars._
    [[partial-code](https://github.com/maxbaluev/accreted-intelligence)]
    _Local-first MCP Work Model for coding agents that retrieves scored memory, records actions, and credits real outcomes; engine is a closed-source binary._
 
--  [agentage Memory](https://memory.agentage.io)
+-  [Agentage Memory](https://memory.agentage.io)
    _Remote MCP memory server (OAuth 2.1 + PKCE + DCR) giving Claude, Cursor, and ChatGPT one shared markdown memory mirrored locally as files you own._
 
 ### Archival


### PR DESCRIPTION
Adds **Agentage Memory**, a remote MCP server (Streamable HTTP) that gives every AI tool one shared markdown memory you own.

- **Endpoint:** `https://memory.agentage.io/mcp`
- **Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (no API key)
- **Website:** https://agentage.io
- **Documentation:** https://agentage.io/blog/mcp-endpoint-is-live
- **Official MCP registry:** `io.agentage/memory`

**Tools (6):** `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, `memory__delete` — one markdown memory that Claude, Cursor, and ChatGPT all read and write, mirrored locally as plain `.md` you can export anytime.

Happy to adjust placement/format to match this list's conventions.
