### PR TITLE
Add FluctlightDB — database engine for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,17 +352,23 @@ _Ordered by the number of Github stars._
       [[code](https://github.com/kevdogg102396-afk/packrat)]
       _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
 
-46. **[Akephalos](https://github.com/sunnja69/akephalos)** 
+46. **[FluctlightDB](https://github.com/voxmastery/FluctlightDB)** 
+      ![Star](https://img.shields.io/github/stars/voxmastery/FluctlightDB.svg?style=social&label=Star)
+      [[code](https://github.com/voxmastery/FluctlightDB)]
+      [[paper](https://doi.org/10.5281/zenodo.20949890)]
+      _Embedded database engine for AI agents with `experience()`/`activate()` API and reproducible LoCoMo evaluation._
+
+47. **[Akephalos](https://github.com/sunnja69/akephalos)** 
       ![Star](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social&label=Star)
       [[code](https://github.com/sunnja69/akephalos)]
       _Local-first, markdown-based portable agent profile (preferences, rules, durable memories) synced across agents via plain files and Git._
 
-47. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
+48. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
       ![Star](https://img.shields.io/github/stars/xiaofanliu525-ctrl/suyi-memory.svg?style=social&label=Star)
       [[code](https://github.com/xiaofanliu525-ctrl/suyi-memory)]
       _Dual-temporal memory engine for AI agents — SQLite-backed, zero-dependency, Ebbinghaus-decayed fact storage with skill crystallization._
 
-48. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
+49. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
       ![Star](https://img.shields.io/github/stars/build-on-ai/consciousness-server.svg?style=social&label=Star)
       [[code](https://github.com/build-on-ai/consciousness-server)]
       _Self-hosted services giving multiple local agents one shared memory — notes, chat, tasks, semantic search, agent registry, ed25519 auth — running fully local with Ollama embeddings._


### PR DESCRIPTION
### FluctlightDB

Embedded **database engine for AI agents** — not a vector DB wrapper.

- API: `experience()` / `activate()` / `checkpoint()`
- LoCoMo **evidence recall:** 98.1% (full 10-conversation set, k=150)
- License: MIT
- Preprint: https://doi.org/10.5281/zenodo.20949890
- Code: https://github.com/voxmastery/FluctlightDB

Placed at #46 by GitHub star count (2 stars, tied with PackRat).

Metric note: evidence recall measures gold dialogue evidence in retrieved context — not end-to-end LLM QA scores.