### PR TITLE
Add Statewave to Open-Source Products

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,46 +329,53 @@ _Ordered by the number of Github stars._
       [[code](https://github.com/maximem-ai/maximem_synap_sdk)]
       [[docs](https://docs.maximem.ai)]
       _Long-term memory layer that extracts facts, preferences, episodes, and temporal events from conversations; integrates with most major agent frameworks._
+    
+42. **[Statewave](https://statewave.ai/)**
+    ![Star](https://img.shields.io/github/stars/smaramwbc/statewave.svg?style=social&label=Star)
+    [[code](https://github.com/smaramwbc/statewave)]
+    [[docs](https://github.com/smaramwbc/statewave-docs)]
+    
+    _Open-source memory runtime for AI agents with durable structured memory, provenance-aware retrieval, episodic storage, and MCP integration._
 
-42. **[archon-memory-core](https://github.com/atw4757-byte/archon-memory-core)** 
+43. **[archon-memory-core](https://github.com/atw4757-byte/archon-memory-core)** 
       ![Star](https://img.shields.io/github/stars/atw4757-byte/archon-memory-core.svg?style=social&label=Star)
       [[code](https://github.com/atw4757-byte/archon-memory-core)]
       _Local-first agent memory with nightly consolidation, active forgetting, and salience scoring._
 
-43. **[Agentic Task System](https://github.com/renezander030/agentic-task-system)**
+44. **[Agentic Task System](https://github.com/renezander030/agentic-task-system)**
       ![Star](https://img.shields.io/github/stars/renezander030/agentic-task-system.svg?style=social&label=Star)
       [[code](https://github.com/renezander030/agentic-task-system)]
       [[npm](https://www.npmjs.com/package/@reneza/ats-cli)]
       _Agent-native context layer over your existing task app (TickTick; Notion/Obsidian planned), exposing hybrid retrieval over tasks/notes to agents via a CLI with pluggable storage adapters._
 
-44. **[Agent Knowledge Cycle](https://github.com/shimo4228/agent-knowledge-cycle)**
+45. **[Agent Knowledge Cycle](https://github.com/shimo4228/agent-knowledge-cycle)**
       ![Star](https://img.shields.io/github/stars/shimo4228/agent-knowledge-cycle.svg?style=social&label=Star)
       [[code](https://github.com/shimo4228/agent-knowledge-cycle)]
       [[paper](https://doi.org/10.5281/zenodo.20578272)]
       _Six-phase knowledge cycle specification (ADRs, JSON schemas, reference implementation) that turns coding-agent sessions into persistent skills, rules, and memory._
 
-45. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
+46. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
       ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
       _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
 
-46. **[FluctlightDB](https://github.com/voxmastery/FluctlightDB)** 
+47. **[FluctlightDB](https://github.com/voxmastery/FluctlightDB)** 
       ![Star](https://img.shields.io/github/stars/voxmastery/FluctlightDB.svg?style=social&label=Star)
       [[code](https://github.com/voxmastery/FluctlightDB)]
       [[paper](https://doi.org/10.5281/zenodo.20949890)]
       _Embedded database engine for AI agents with `experience()`/`activate()` API and reproducible LoCoMo evaluation._
 
-47. **[Akephalos](https://github.com/sunnja69/akephalos)** 
+48. **[Akephalos](https://github.com/sunnja69/akephalos)** 
       ![Star](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social&label=Star)
       [[code](https://github.com/sunnja69/akephalos)]
       _Local-first, markdown-based portable agent profile (preferences, rules, durable memories) synced across agents via plain files and Git._
 
-48. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
+49. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
       ![Star](https://img.shields.io/github/stars/xiaofanliu525-ctrl/suyi-memory.svg?style=social&label=Star)
       [[code](https://github.com/xiaofanliu525-ctrl/suyi-memory)]
       _Dual-temporal memory engine for AI agents — SQLite-backed, zero-dependency, Ebbinghaus-decayed fact storage with skill crystallization._
 
-49. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
+50. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
       ![Star](https://img.shields.io/github/stars/build-on-ai/consciousness-server.svg?style=social&label=Star)
       [[code](https://github.com/build-on-ai/consciousness-server)]
       _Self-hosted services giving multiple local agents one shared memory — notes, chat, tasks, semantic search, agent registry, ed25519 auth — running fully local with Ollama embeddings._


### PR DESCRIPTION
## What does this PR add or change?

Adds Statewave to the **Open-Source Products** section.

Statewave is an open-source memory runtime for AI agents that provides durable, structured memory with provenance, episodic storage, semantic retrieval, and MCP integration.

## Checklist

- [x] Not already listed (searched the README, including alternative names)
- [x] Links point to primary sources and resolve
- [x] Entry follows the format in CONTRIBUTING.md (one-line factual description, correct section)
- [x] Open-source product placed according to current GitHub star count
- [x] File keeps LF line endings