### PR TITLE
Add mnemo poisoning probes to Memory Security & Defense

### DIFF
--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,12 @@ _Ordered by the number of Github stars._
 - [From Untrusted Input to Trusted Memory: A Systematic Study of Memory Poisoning Attacks in LLM Agents](https://arxiv.org/abs/2606.04329)
     (The MPBench Paper)
 
+- **[mnemo poisoning probes](https://github.com/DanceNitra/agora/tree/main/mnemo/probes)**
+    [[attack](https://github.com/DanceNitra/agora/blob/main/mnemo/probes/memory_defense_layer_probe.py)]
+    [[defense](https://github.com/DanceNitra/agora/blob/main/mnemo/probes/memory_gate_defense_probe.py)]
+    _Runnable receipts across 10 models: provenance/corroboration written INTO a memory record is forgeable (~0.9 attack-success); only an earned, un-self-gradable corroboration gate applied at retrieval holds — and it prices, not closes, the attack (Cheng–Friedman residual)._
+
+
 ---
 
 ## 📰 Articles


### PR DESCRIPTION
Adds a runnable-probe entry to **🔒 Memory Security & Defense**.

Full disclosure: this is our own open-source work. It's a direct, measured counterpoint to the provenance-verification approach in the existing *Agent Memory Guard* entry — we ran a defense-aware attacker across 10 models (8 families) and found that provenance/corroboration written **into** a memory record is forgeable (~0.9 attack-success); the only signal that holds is earned, un-self-gradable corroboration applied at retrieval — and even that *prices* rather than *closes* the attack (Cheng–Friedman: no symmetric reputation is sybilproof). Both an attack probe and a defense probe are runnable on any OpenAI-compatible endpoint, no keys embedded.

Happy to adjust placement/wording, shorten, or drop if it's out of scope — thanks for keeping this list useful.