### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,22 +365,27 @@ _Ordered by the number of Github stars._
       [[code](https://github.com/kevdogg102396-afk/packrat)]
       _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
 
-48. **[Context Kit](https://github.com/JDDavenport/context-kit)** 
+48. **[Tree Ring Memory](https://terminallylazy.github.io/Tree-Ring-Memory/)**
+      ![Star](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory.svg?style=social&label=Star)
+      [[code](https://github.com/TerminallyLazy/Tree-Ring-Memory)]
+      _Local-first memory lifecycle for AI agents with a Rust CLI, SQLite/FTS recall, audit, forgetting, consolidation, and Ratatui TUI._
+
+49. **[Context Kit](https://github.com/JDDavenport/context-kit)**
       ![Star](https://img.shields.io/github/stars/JDDavenport/context-kit.svg?style=social&label=Star)
       [[code](https://github.com/JDDavenport/context-kit)]
       _Markdown "personal context artifact" templates plus Claude Code skills and an MCP server that load durable identity, preferences, and project context into agents._
 
-49. **[Akephalos](https://github.com/sunnja69/akephalos)** 
+50. **[Akephalos](https://github.com/sunnja69/akephalos)**
       ![Star](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social&label=Star)
       [[code](https://github.com/sunnja69/akephalos)]
       _Local-first, markdown-based portable agent profile (preferences, rules, durable memories) synced across agents via plain files and Git._
 
-50. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
+51. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
       ![Star](https://img.shields.io/github/stars/xiaofanliu525-ctrl/suyi-memory.svg?style=social&label=Star)
       [[code](https://github.com/xiaofanliu525-ctrl/suyi-memory)]
       _Dual-temporal memory engine for AI agents — SQLite-backed, zero-dependency, Ebbinghaus-decayed fact storage with skill crystallization._
 
-51. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
+52. **[consciousness-server](https://github.com/build-on-ai/consciousness-server)**
       ![Star](https://img.shields.io/github/stars/build-on-ai/consciousness-server.svg?style=social&label=Star)
       [[code](https://github.com/build-on-ai/consciousness-server)]
       _Self-hosted services giving multiple local agents one shared memory — notes, chat, tasks, semantic search, agent registry, ed25519 auth — running fully local with Ollama embeddings._

--- a/README.md
+++ b/README.md
@@ -360,15 +360,15 @@ _Ordered by the number of Github stars._
       [[paper](https://doi.org/10.5281/zenodo.20949890)]
       _Embedded database engine for AI agents with `experience()`/`activate()` API and reproducible LoCoMo evaluation._
 
-47. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
-      ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
-      [[code](https://github.com/kevdogg102396-afk/packrat)]
-      _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
-
-48. **[Tree Ring Memory](https://terminallylazy.github.io/Tree-Ring-Memory/)**
+47. **[Tree Ring Memory](https://terminallylazy.github.io/Tree-Ring-Memory/)**
       ![Star](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory.svg?style=social&label=Star)
       [[code](https://github.com/TerminallyLazy/Tree-Ring-Memory)]
       _Local-first memory lifecycle for AI agents with a Rust CLI, SQLite/FTS recall, audit, forgetting, consolidation, and Ratatui TUI._
+
+48. **[PackRat](https://github.com/kevdogg102396-afk/packrat)** 
+      ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
+      [[code](https://github.com/kevdogg102396-afk/packrat)]
+      _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
 
 49. **[Context Kit](https://github.com/JDDavenport/context-kit)**
       ![Star](https://img.shields.io/github/stars/JDDavenport/context-kit.svg?style=social&label=Star)


### PR DESCRIPTION
## Summary

- Add Tree Ring Memory to the open-source Products section.
- Use the standard star badge and code link format from `CONTRIBUTING.md`.
- Place it near the bottom of the star-ordered list based on its current GitHub star count.

## Links

- Homepage: https://terminallylazy.github.io/Tree-Ring-Memory/
- Code: https://github.com/TerminallyLazy/Tree-Ring-Memory

## Checks

- Searched the README for an existing Tree Ring Memory entry.
- Verified the project is an open-source agent-memory product.
- Ran `git diff --check`.
