### PR TITLE
Add Data Olympus

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,11 @@ _Ordered by the number of Github stars._
       [[code](https://github.com/build-on-ai/consciousness-server)]
       _Self-hosted services giving multiple local agents one shared memory — notes, chat, tasks, semantic search, agent registry, ed25519 auth — running fully local with Ollama embeddings._
 
+52. **[Data Olympus](https://github.com/knaisoma/data-olympus)**
+      ![Star](https://img.shields.io/github/stars/knaisoma/data-olympus.svg?style=social&label=Star)
+      [[code](https://github.com/knaisoma/data-olympus)]
+      _Governed project memory for AI coding agents: agents can propose learnings, humans promote them, and MCP retrieval serves only in-force knowledge after validity and supersession checks._
+
 ### Closed-Source
 
 -  [MemoryLake](https://www.memorylake.ai/en)


### PR DESCRIPTION
## What does this PR add or change?

Adds Data Olympus to the Open-Source products section. Data Olympus is a governed project-memory layer for AI coding agents: agents can propose learnings, humans promote accepted guidance, and MCP retrieval serves only in-force knowledge after validity-window and supersession checks.

## Checklist

- [x] Not already listed (searched the README, including alternative names)
- [x] Links point to primary sources and resolve
- [x] Entry follows the format in [CONTRIBUTING.md](../CONTRIBUTING.md) (one-line factual description, correct section/year)
- [x] Open-source products: placed at the position matching current GitHub star count
- [x] File keeps LF line endings