### PR TITLE
Add screenpipe to agent memory products

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,14 +317,14 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/memovai/memov)]
       _Git-based, traceable memory layer for Claude Code._
 
-34. **[OMEGA](https://omegamax.co)** ![Star](https://img.shields.io/github/stars/omega-memory/omega-memory.svg?style=social&label=Star)
+34. **[Mnemory](https://github.com/fpytloun/mnemory)** ![Star](https://img.shields.io/github/stars/fpytloun/mnemory.svg?style=social&label=Star)
+      [[code](https://github.com/fpytloun/mnemory)]
+      _Multi-type agent memory (facts, preferences, episodic) with TTLs, user/agent scoping, and an MCP server._
+
+35. **[OMEGA](https://omegamax.co)** ![Star](https://img.shields.io/github/stars/omega-memory/omega-memory.svg?style=social&label=Star)
       [[code](https://github.com/omega-memory/omega-memory)]
       [[blog](https://omegamax.co/blog)]
       _MCP server exposing 25 memory tools for AI coding agents._
-
-35. **[Mnemory](https://github.com/fpytloun/mnemory)** ![Star](https://img.shields.io/github/stars/fpytloun/mnemory.svg?style=social&label=Star)
-      [[code](https://github.com/fpytloun/mnemory)]
-      _Multi-type agent memory (facts, preferences, episodic) with TTLs, user/agent scoping, and an MCP server._
 
 36. **[projectmem](https://projectmem.dev)**
       ![Star](https://img.shields.io/github/stars/riponcm/projectmem.svg?style=social&label=Star)
@@ -480,6 +480,12 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
 
 -  [Agentage Memory](https://memory.agentage.io)
    _Remote MCP memory server (OAuth 2.1 + PKCE + DCR) giving Claude, Cursor, and ChatGPT one shared markdown memory mirrored locally as files you own._
+
+-  [screenpipe](https://screenpipe.com)
+   [[source-available](https://github.com/screenpipe/screenpipe)]
+   [[license](https://github.com/screenpipe/screenpipe/blob/main/LICENSE.md)]
+   [[docs](https://docs.screenpi.pe)]
+   _Local-first work memory that captures screen, audio, input, browser, and meeting context for search and agent retrieval._
 
 ### Archival
 


### PR DESCRIPTION
## What does this PR add or change?

Adds screenpipe to Closed-Source products as a local-first work-memory product for agent retrieval.

The current repository is source-available under the Screenpipe Commercial License, so the entry deliberately uses the closed-source section rather than the open-source star ranking. It links the source, current license, and documentation directly and makes no performance claims.

This also swaps Mnemory and OMEGA because their live star counts had drifted by one and the repository star-order check otherwise failed before evaluating this contribution.

Disclosure: I maintain screenpipe.

## Checklist

- [x] Not already listed (searched the README, including alternative names)
- [x] Links point to primary sources and resolve
- [x] Entry follows the format in CONTRIBUTING.md (17-word factual description, correct section)
- [x] Open-source star placement is not applicable
- [x] File keeps LF line endings

Local validation:
- GITHUB_TOKEN set; python3 scripts/check_star_order.py README.md passes
- git diff --check
- all four added links returned HTTP 200