### PR TITLE
Add mnemo (Emerging) and the Agent-Memory Integrity Benchmark (2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,11 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       ![Star](https://img.shields.io/github/stars/xiaofanliu525-ctrl/suyi-memory.svg?style=social&label=Star)
       [[code](https://github.com/xiaofanliu525-ctrl/suyi-memory)]
       _Dual-temporal memory engine for AI agents — SQLite-backed, zero-dependency, Ebbinghaus-decayed fact storage with skill crystallization._
+58. **[mnemo](https://github.com/DanceNitra/mnemo)**
+      ![Star](https://img.shields.io/github/stars/DanceNitra/mnemo.svg?style=social&label=Star)
+      [[code](https://github.com/DanceNitra/mnemo)]
+      [[pypi](https://pypi.org/project/agora-mnemo/)]
+      _Zero-dependency memory layer and MCP server: value-ranked recall, per-type decay, deterministic keyed supersession, and a first-class correction channel — revert, a read-path review-trigger (observe/reopen), signed provenance grounds, tamper-evident receipts, and cross-store erasure._
 
 </details>
 
@@ -524,6 +529,10 @@ _Projects that are inactive or whose claims have been disputed by third parties.
 ## 📖 Tutorials
 
 #### 🗓️ 2026
+
+- **[Agent-Memory Integrity Benchmark](https://github.com/DanceNitra/agent-memory-integrity)**
+    [[code](https://github.com/DanceNitra/agent-memory-integrity)]
+    _Open cross-system harness for memory integrity under correction (value-obscuring revert + echo resurrection) — the axis recall benchmarks skip; a shared ground-truth-blind judge, run across mnemo, mem0, and Graphiti._
 
  - **[Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques)** (NirDiamant): 30 runnable Jupyter notebooks covering conversation buffers, vector stores, knowledge graphs, episodic and semantic memory, Mem0, MemGPT/Letta, Zep, Graphiti, and LoCoMo benchmarks
      [[code](https://github.com/NirDiamant/Agent_Memory_Techniques)]

--- a/README.md
+++ b/README.md
@@ -428,31 +428,32 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/TerminallyLazy/Tree-Ring-Memory)]
       _Local-first memory lifecycle for AI agents with a Rust CLI, SQLite/FTS recall, audit, forgetting, consolidation, and Ratatui TUI._
 
-54. **[Agent Knowledge Cycle](https://github.com/shimo4228/agent-knowledge-cycle)**
+54. **[mnemo](https://github.com/DanceNitra/mnemo)**
+      ![Star](https://img.shields.io/github/stars/DanceNitra/mnemo.svg?style=social&label=Star)
+      [[code](https://github.com/DanceNitra/mnemo)]
+      [[pypi](https://pypi.org/project/agora-mnemo/)]
+      _Zero-dependency memory layer and MCP server with value-ranked recall, per-type decay, keyed supersession, revert-based correction, signed provenance, tamper-evident receipts, and cross-store erasure._
+
+55. **[Agent Knowledge Cycle](https://github.com/shimo4228/agent-knowledge-cycle)**
       ![Star](https://img.shields.io/github/stars/shimo4228/agent-knowledge-cycle.svg?style=social&label=Star)
       [[code](https://github.com/shimo4228/agent-knowledge-cycle)]
       [[paper](https://doi.org/10.5281/zenodo.20578272)]
       _Six-phase knowledge cycle specification (ADRs, JSON schemas, reference implementation) that turns coding-agent sessions into persistent skills, rules, and memory._
 
-55. **[PackRat](https://github.com/kevdogg102396-afk/packrat)**
+56. **[PackRat](https://github.com/kevdogg102396-afk/packrat)**
       ![Star](https://img.shields.io/github/stars/kevdogg102396-afk/packrat.svg?style=social&label=Star)
       [[code](https://github.com/kevdogg102396-afk/packrat)]
       _Auto-learning codebook compression that shrinks agent context files while keeping them LLM-readable._
 
-56. **[Akephalos](https://github.com/sunnja69/akephalos)**
+57. **[Akephalos](https://github.com/sunnja69/akephalos)**
       ![Star](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social&label=Star)
       [[code](https://github.com/sunnja69/akephalos)]
       _Local-first, markdown-based portable agent profile (preferences, rules, durable memories) synced across agents via plain files and Git._
 
-57. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
+58. **[溯忆 (Suyi)](https://github.com/xiaofanliu525-ctrl/suyi-memory)**
       ![Star](https://img.shields.io/github/stars/xiaofanliu525-ctrl/suyi-memory.svg?style=social&label=Star)
       [[code](https://github.com/xiaofanliu525-ctrl/suyi-memory)]
       _Dual-temporal memory engine for AI agents — SQLite-backed, zero-dependency, Ebbinghaus-decayed fact storage with skill crystallization._
-58. **[mnemo](https://github.com/DanceNitra/mnemo)**
-      ![Star](https://img.shields.io/github/stars/DanceNitra/mnemo.svg?style=social&label=Star)
-      [[code](https://github.com/DanceNitra/mnemo)]
-      [[pypi](https://pypi.org/project/agora-mnemo/)]
-      _Zero-dependency memory layer and MCP server: value-ranked recall, per-type decay, deterministic keyed supersession, and a first-class correction channel — revert, a read-path review-trigger (observe/reopen), signed provenance grounds, tamper-evident receipts, and cross-store erasure._
 
 </details>
 
@@ -529,10 +530,6 @@ _Projects that are inactive or whose claims have been disputed by third parties.
 ## 📖 Tutorials
 
 #### 🗓️ 2026
-
-- **[Agent-Memory Integrity Benchmark](https://github.com/DanceNitra/agent-memory-integrity)**
-    [[code](https://github.com/DanceNitra/agent-memory-integrity)]
-    _Open cross-system harness for memory integrity under correction (value-obscuring revert + echo resurrection) — the axis recall benchmarks skip; a shared ground-truth-blind judge, run across mnemo, mem0, and Graphiti._
 
  - **[Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques)** (NirDiamant): 30 runnable Jupyter notebooks covering conversation buffers, vector stores, knowledge graphs, episodic and semantic memory, Mem0, MemGPT/Letta, Zep, Graphiti, and LoCoMo benchmarks
      [[code](https://github.com/NirDiamant/Agent_Memory_Techniques)]
@@ -622,6 +619,9 @@ _Projects that are inactive or whose claims have been disputed by third parties.
 
 - **LoCoMo Refined: Recalibrating LoCoMo with Stricter LLM Judging and A Cleaned Dataset**
     [[code](https://github.com/mem-eval-suite/LoCoMo_refined)]
+
+- **Agent-Memory Integrity Benchmark**
+    [[code](https://github.com/DanceNitra/agent-memory-integrity)]
 
 #### 🗓️ 2025
 


### PR DESCRIPTION
Two open-source additions, both with runnable code and factual descriptions per the list's convention:

**Products → Emerging projects** — [**mnemo**](https://github.com/DanceNitra/mnemo) (PyPI `agora-mnemo`): a zero-dependency memory layer and MCP server. Beyond value-ranked recall / per-type decay, its focus is a **first-class correction channel** — deterministic keyed supersession, `revert`, a read-path review-trigger (`observe`/`reopened`/`resolve_reopened`), optional signed provenance grounds, tamper-evident receipts, and cross-store erasure.

**Benchmarks → Plain-Text → 2026** — [**Agent-Memory Integrity Benchmark**](https://github.com/DanceNitra/agent-memory-integrity): an open cross-system harness for memory **integrity under correction** (value-obscuring revert + echo resurrection) — the axis recall benchmarks skip. Shared ground-truth-blind judge; runs mnemo, mem0, and Graphiti; adapter interface to add a system.

Note: the repo already lists our 'mnemo poisoning probes' under Memory Security & Defense; these two add the library itself and the integrity benchmark. Happy to adjust placement/wording to match your conventions.