### PR TITLE
Add "Useful Memories Become Faulty When Continuously Updated by LLMs" to Memory for Agent Evolution (2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,8 @@ _Projects that are inactive or whose claims have been disputed by third parties.
 
 - [Meta-Cognitive Memory Policy Optimization for Long-Horizon LLM Agents](https://arxiv.org/abs/2605.30159)
 
+- [Useful Memories Become Faulty When Continuously Updated by LLMs](https://arxiv.org/abs/2605.12978)
+
 - [MEMTIER: Tiered Memory Architecture and Retrieval Bottleneck Analysis for Long-Running Autonomous AI Agents](https://arxiv.org/abs/2605.03675)
 
 - [Neural Garbage Collection: Learning to Forget while Learning to Reason](https://arxiv.org/abs/2604.18002)


### PR DESCRIPTION
## What does this PR add or change?

Adds the paper **"Useful Memories Become Faulty When Continuously Updated by LLMs"** ([arXiv 2605.12978](https://arxiv.org/abs/2605.12978), May 2026) to **Papers - Memory for Agent Evolution → Reinforcement Learning & Continual Learning → 2026**, as a plain (non-bold) entry.

## Checklist

- [x] Not already listed (searched the README, including alternative names)
- [x] Links point to primary sources and resolve
- [x] Entry follows the format in [CONTRIBUTING.md](../CONTRIBUTING.md) (one-line factual description, correct section/year)
- [x] Open-source products: placed at the position matching current GitHub star count — N/A (paper, not a product)
- [x] File keeps LF line endings

Note: added without a `[[code]]` link / non-bold, as no public reproducible-code repository is listed on the arXiv abstract page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)