### PR TITLE
Add kgai (decision-memory graph for coding agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
 63. **[kgai](https://kgai.dev)**
       ![Star](https://img.shields.io/github/stars/kgaidev/kgai.svg?style=social&label=Star)
       [[code](https://github.com/kgaidev/kgai)]
-      _Local-first immutable knowledge graph of engineering decisions for AI coding agents: deterministic supersession keeps the old decision and the reason it died, so the agent stops re-proposing what the team already rejected; embedded graph DB, opt-in team sync._
+      _Local-first immutable knowledge graph of engineering decisions for AI coding agents; superseded decisions and rejected approaches stay queryable; embedded graph DB, opt-in team sync._
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -479,6 +479,11 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/panellatech/panella)]
       _Self-hosted governed memory over MCP; agent writes become durable only after human approval with verifiable receipts; Apache-2.0._
 
+63. **[kgai](https://kgai.dev)**
+      ![Star](https://img.shields.io/github/stars/kgaidev/kgai.svg?style=social&label=Star)
+      [[code](https://github.com/kgaidev/kgai)]
+      _Local-first immutable knowledge graph of engineering decisions for AI coding agents: deterministic supersession keeps the old decision and the reason it died, so the agent stops re-proposing what the team already rejected; embedded graph DB, opt-in team sync._
+
 </details>
 
 ### Closed-Source


### PR DESCRIPTION
Adds kgai to the Emerging projects section (Open-Source, <100 stars).

kgai is an MIT open-source, local-first knowledge graph of engineering decisions, built as memory for AI coding agents. Decisions are immutable; a new decision supersedes the old one and the reason it died stays in history, so the agent stops re-proposing approaches the team already rejected. Dead ends are kept on purpose. Uses an embedded graph DB (Kuzu); team sync is opt-in over an S3 bucket you own.

- Repo: https://github.com/kgaidev/kgai
- Site: https://kgai.dev
- License: MIT

Placed at the end of Emerging projects per the <100-star ordering rule.