### PR TITLE
Rename engRAM to Compartment

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,9 +491,9 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/kgaidev/kgai)]
       _Local-first immutable knowledge graph of engineering decisions for AI coding agents; superseded decisions and rejected approaches stay queryable; embedded graph DB, opt-in team sync._
 
-65. **[engRAM](https://github.com/MaxFreedomPollard/engRAM)**
-      ![Star](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM.svg?style=social&label=Star)
-      [[code](https://github.com/MaxFreedomPollard/engRAM)]
+65. **[Compartment](https://github.com/MaxFreedomPollard/Compartment)**
+      ![Star](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment.svg?style=social&label=Star)
+      [[code](https://github.com/MaxFreedomPollard/Compartment)]
       _Offline, encrypted-at-rest vector memory for agents via MCP server, Python, or CLI; AEAD-encrypted embeddings, hybrid recall, per-record crypto-shred deletion, hash-chained audit log._
 
 </details>


### PR DESCRIPTION
Entry 65 in *Emerging projects (Open-Source)* was added as **engRAM** (#69). The project has since been **renamed to Compartment**.

This updates the name, the repository links and the star badge. Nothing else changes — the description, numbering and formatting are untouched.

- New repository: https://github.com/MaxFreedomPollard/Compartment
- The old `engRAM` URL still redirects, so the existing links are not broken — but the badge renders against the old path and the name shown is now wrong.

Thanks for maintaining the list.