### PR TITLE
Add memgres to Emerging projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,11 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/MaxFreedomPollard/engRAM)]
       _Offline, encrypted-at-rest vector memory for agents via MCP server, Python, or CLI; AEAD-encrypted embeddings, hybrid recall, per-record crypto-shred deletion, hash-chained audit log._
 
+66. **[memgres](https://github.com/mozgsml/memgres)**
+      ![Star](https://img.shields.io/github/stars/mozgsml/memgres.svg?style=social&label=Star)
+      [[code](https://github.com/mozgsml/memgres)]
+      _Versioned document memory for AI agents over one Postgres; lexical or semantic recall, diff-based history, git-blame line attribution, GDPR-erasable, multi-tenant via MCP/HTTP._
+
 </details>
 
 ### Closed-Source


### PR DESCRIPTION
Adds **memgres** to the Emerging projects block (open-source, <100 stars).

- **Repo:** https://github.com/mozgsml/memgres (MIT)
- **What it is:** an open-source memory layer for AI agents — a Python library plus HTTP and **memory MCP server**, backed by a single PostgreSQL database.
- **In scope:** memory is the primary purpose (document memory with authored diffs), not a minor feature of a general framework.

Followed CONTRIBUTING.md:
- Placed inside the collapsed **Emerging projects** `<details>` block, numbering continued (#66) after the last entry.
- Star-badge + `[[code]]` entry format; factual one-line description (≤25 words), no superlatives/pricing.
- LF line endings; links verified; not already listed; no maintainer affiliation (no †).

🤖 Generated with [Claude Code](https://claude.com/claude-code)