### PR TITLE
Add FeedRecall to emerging open-source agent memory projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,11 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/0xboyu/aml-memory-mvp)]
       _Evidence-only retriever indexing English and CJK text with SQLite FTS5 plus character n-grams, typo-tolerant semantic retrieval, and conversation-neighbor expansion; #10 on the Agent Memory Leaderboard academic textual track (2026-08)._
 
+82. **[FeedRecall](https://github.com/Paoladev45/feedrecall)**
+      ![Star](https://img.shields.io/github/stars/Paoladev45/feedrecall.svg?style=social&label=Star)
+      [[code](https://github.com/Paoladev45/feedrecall)]
+      _Local-first MCP memory for saved social discoveries, with source dates, project relevance, evidence lifecycle, timelines, and bounded recall for coding agents._
+
 </details>
 
 ### Closed-Source


### PR DESCRIPTION
## Summary

Add FeedRecall to the Emerging projects section.

FeedRecall is a public Apache-2.0, local-first MCP memory layer for human-selected social discoveries. It preserves source dates, project relevance, evidence lifecycle, timelines, and bounded recall for coding agents.

The entry is placed at the end of the under-100-stars section because the repository currently has zero stars. The description is factual and follows the contribution format.