### PR TITLE
Add Verified Memory Vault to Emerging projects (Open-Source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
 90. **[Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault)**
       ![Star](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault.svg?style=social&label=Star)
       [[code](https://github.com/secondbrainstarter/verified-memory-vault)]
-      _Plain-markdown Obsidian vault that doubles as Claude Code memory: a deterministic health-score linter scans for undated entries, duplicates, budget overflow and dead links; a git pre-commit hook refuses mass deletions._
+      _Obsidian vault doubling as Claude Code memory: deterministic health-score linter (undated entries, duplicates, dead links) plus a git pre-commit hook refusing mass deletions._
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -624,6 +624,11 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/tonydzi/claude-memory-tidy)]
       _Maintenance layer for always-loaded agent memory files: deterministic budget guard, orphan-note coverage, and verbatim folding into warm sub-indexes, guarding against silent truncation._
 
+90. **[Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault)**
+      ![Star](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault.svg?style=social&label=Star)
+      [[code](https://github.com/secondbrainstarter/verified-memory-vault)]
+      _Plain-markdown Obsidian vault that doubles as Claude Code memory: a deterministic health-score linter scans for undated entries, duplicates, budget overflow and dead links; a git pre-commit hook refuses mass deletions._
+
 </details>
 
 ### Closed-Source

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/tonydzi/claude-memory-tidy)]
       _Maintenance layer for always-loaded agent memory files: deterministic budget guard, orphan-note coverage, and verbatim folding into warm sub-indexes, guarding against silent truncation._
 
-90. **[Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault)**
+92. **[Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault)**
       ![Star](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault.svg?style=social&label=Star)
       [[code](https://github.com/secondbrainstarter/verified-memory-vault)]
       _Obsidian vault doubling as Claude Code memory: deterministic health-score linter (undated entries, duplicates, dead links) plus a git pre-commit hook refusing mass deletions._


### PR DESCRIPTION
Adds **Verified Memory Vault** to the Emerging projects section (Open-Source products), continuing the numbering at 90 per the current README.

Why this fits the list's scope:
- Primary purpose is memory for coding agents: a plain-markdown Obsidian vault structured as persistent Claude Code memory (CLAUDE.md boot file, append-only MEMORY.md), read and written by the agent itself.
- Memory hygiene tooling: `memory_check.py` computes a deterministic health score over the memory files — undated entries, duplicates, per-file budget overflow, dead wikilinks, inbox pressure — exit-code capable for CI.
- Memory-destruction protection: `memory_guard.py` is a git pre-commit hook that refuses commits deleting more than a few memory files or removing MEMORY.md lines without an archive move.

Format follows CONTRIBUTING.md: numbered entry at the end of the Emerging projects block (fewer than 100 stars), star badge + code link, one-line factual description ≤ 25 words, LF endings. License: CC BY 4.0 (vault) / MIT (tools). Links verified to resolve.

Not listed anywhere else in the README (checked).