### PR TITLE
Add an agent-memory architecture decision guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,8 @@ _Projects that are inactive or whose claims have been disputed by third parties.
  - **[Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques)** (NirDiamant): 30 runnable Jupyter notebooks covering conversation buffers, vector stores, knowledge graphs, episodic and semantic memory, Mem0, MemGPT/Letta, Zep, Graphiti, and LoCoMo benchmarks
      [[code](https://github.com/NirDiamant/Agent_Memory_Techniques)]
 
+- **[Choose an agent-memory architecture](https://sir-ad.github.io/awesome-memory/guide.html)** (sir-ad): Decision guide mapping four memory jobs to five architecture patterns, minimum controls, evaluation baselines, and primary research.
+
 - **[Tools, Actions, Memory, and Context](https://books.bloo-mind.ai/masact/ch-04-tools-actions-environments)** †: Chapter 4 of the textbook _[Multi-Agent Systems: A Contemporary Treatment](https://books.bloo-mind.ai/masact/)_.
 
 #### 🗓️ 2025


### PR DESCRIPTION
## Summary

- add the 2026 “Choose an agent-memory architecture” tutorial
- describe its four-memory-job, five-pattern scope and evidence boundary

## Why it belongs

The contribution guide welcomes substantial educational content about agent memory. This decision guide maps working, factual, episodic, and procedural memory jobs to architecture patterns, poor-fit cases, minimum controls, evaluation baselines, and primary research. It is not a product announcement.

## Validation

- confirmed the resource is not already listed
- verified the live tutorial returns HTTP 200
- ran git diff --check
- kept the change to one 2026 tutorial entry

Affiliation: I maintain the linked guide and repository.