### PR TITLE
Add RCLL to Emerging projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,13 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/tonydzi/claude-memory-tidy)]
       _Maintenance layer for always-loaded agent memory files: deterministic budget guard, orphan-note coverage, and verbatim folding into warm sub-indexes, guarding against silent truncation._
 
+94. **[RCLL](https://rcll.ai)**
+      ![Star](https://img.shields.io/github/stars/holetron-lab/fleet-memory.svg?style=social&label=Star)
+      [[code](https://github.com/holetron-lab/fleet-memory)]
+      [[docs](https://rcll.ai/docs/)]
+      [[eval](https://rcll.ai/docs/benchmarks/)]
+      _Self-hosted shared memory for a fleet of agents: topic rooms, L0–L3 depth, Postgres/pgvector; the read path invokes no language model. Fork of Hindsight._
+
 </details>
 
 ### Closed-Source


### PR DESCRIPTION
Adds RCLL under **Emerging projects** (0 stars, so it belongs in the collapsed block by your threshold rule).

Position: **#94**, appended after #93 `claude-memory-tidy`. Entries #84–93 are all at 0 stars, so this is the tie position — and it is exactly where `scripts/check_star_order.py` places it in its own suggested order.

**On the red CI:** `check_star_order.py` exits 1 on unmodified `main` as well, for a pre-existing inversion at **#54/#55** (Belief Context Graph 41★ vs memclaw 40★) that has nothing to do with this entry. I ran it on both; the outputs differ by exactly the one line this PR adds. Please don't read that failure as this change.

Description is factual, no install command and no package-registry link, per the entry format. Link labels: `code`, `docs`, `eval` — `eval` points at our own published retrieval numbers, self-reported as your guide says that label means, with the harness named and the arms that lose included.

`vectorize-io/hindsight`, which RCLL forks, is already in the main list. This is a fork with a different scoping model (topic-scoped rooms over one shared store for a team of agents), not a duplicate submission — the description says so.