### PR TITLE
Add Firekeep to Closed-Source products

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,12 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
    [[docs](https://docs.screenpi.pe)]
    _Local-first work memory that captures screen, audio, input, browser, and meeting context for search and agent retrieval._
 
+-  [Firekeep](https://firekeep.ai/)
+   [[source-available](https://github.com/kapella-hub/FirekeepHQ)]
+   [[license](https://github.com/kapella-hub/FirekeepHQ/blob/main/LICENSE)]
+   [[docs](https://firekeep.ai/docs.html)]
+   _Self-hosted shared memory, working context, coordination, and evidence for Claude Code, Codex, Kiro, OpenCode, and other MCP clients._
+
 ### Archival
 
 _Projects that are inactive or whose claims have been disputed by third parties. Status labels link to the evidence and note when the status was last checked._


### PR DESCRIPTION
## What does this PR add or change?

Add Firekeep to Closed-Source products as a source-available product under BUSL-1.1.

## Checklist

- [x] Not already listed (searched the README, including alternative names)
- [x] Links point to primary sources and resolve
- [x] Entry follows the format in [CONTRIBUTING.md](../CONTRIBUTING.md) (one-line factual description, correct section/year)
- [x] Open-source products: not applicable; Firekeep is listed under Closed-Source because BUSL-1.1 is source-available
- [x] File keeps LF line endings