### PR TITLE
Add ExperienceNet to Emerging products

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,12 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[eval](https://rcll.ai/docs/benchmarks/)]
       _Self-hosted shared memory for a fleet of agents: topic rooms, L0–L3 depth, Postgres/pgvector; the read path invokes no language model. Fork of Hindsight._
 
+96. **[ExperienceNet](https://experiencenet.cloud/)**
+      ![Star](https://img.shields.io/github/stars/cu-min/experiencenet.svg?style=social&label=Star)
+      [[code](https://github.com/cu-min/experiencenet)]
+      [[docs](https://github.com/cu-min/experiencenet/blob/master/docs/API.md)]
+      _Self-hosted experience network for agents: search and write real technical attempts (problem/conditions/action/outcome), lexical + semantic hybrid retrieval over PostgreSQL/pgvector, gap capture, reuse feedback._
+
 </details>
 
 ### Closed-Source

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[eval](https://rcll.ai/docs/benchmarks/)]
       _Self-hosted shared memory for a fleet of agents: topic rooms, L0–L3 depth, Postgres/pgvector; the read path invokes no language model. Fork of Hindsight._
 
-96. **[ExperienceNet](https://experiencenet.cloud/)**
+96. **[ExperienceNet](https://github.com/cu-min/experiencenet)**
       ![Star](https://img.shields.io/github/stars/cu-min/experiencenet.svg?style=social&label=Star)
       [[code](https://github.com/cu-min/experiencenet)]
       [[docs](https://github.com/cu-min/experiencenet/blob/master/docs/API.md)]


### PR DESCRIPTION
## What

Adds [ExperienceNet](https://github.com/cu-min/experiencenet) as entry 96 in the Emerging projects section.

- **Scope check**: open-source product whose primary purpose is memory for LLM agents — a self-hosted experience network where agents search, write, and feed back on real technical attempts (problem / conditions / action / outcome tuples).
- **Placement**: <100 stars, so it goes at the end of the Emerging `<details>` block per the contributing guide, numbering continues from 95.
- **Description**: factual, 23 words, no superlatives.
- **Links verified**: homepage, code, and docs all resolve.
- **Format**: numbered entry with star badge, `code` / `docs` link labels, LF line endings preserved.

Disclosure: I am the maintainer of the project being submitted.

Happy to adjust wording or position if anything is off.
