### PR TITLE
Add agent-memory-bench to 2026 dynamic benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,6 +1023,11 @@ _Projects that are inactive or whose claims have been disputed by third parties.
 
 - [StreamMemBench: Streaming Evaluation of Agent Memory for Future-Oriented Assistance](https://arxiv.org/abs/2606.14571)
 
+- **[agent-memory-bench](https://giulioder.github.io/agent-memory-bench/)**
+    [[code](https://github.com/GiulioDER/agent-memory-bench)]
+    [[data](https://huggingface.co/datasets/Gde05/agent-memory-bench-corpus)]
+    _Preregistered harness scoring memory layers for coding agents by executing task checkers rather than judging text; the author's own RE-call is among the arms._
+
 #### 🗓️ 2025
 
 - **[MemoryBench: A Benchmark for Memory and Continual Learning in LLM Systems](https://arxiv.org/abs/2510.17281)**


### PR DESCRIPTION
**Affiliation: I maintain this project.** RE-call, one of the arms, is also mine. Both facts are stated in the entry description, following the precedent of the Vectorize/Hindsight entry in the plain-text section.

## What it is

[agent-memory-bench](https://github.com/GiulioDER/agent-memory-bench) scores memory layers for **coding agents** by giving a real agent real work in a real repository, where success depends on something established in an earlier session, and grading the resulting artifact **by execution**: the task's checker passes or it does not. There is no LLM judge anywhere in the primary endpoint.

Arms currently on the board: `bare`, `placebo`, `claude_md`, `fs_grep`, `recall`, `mempalace`, plus `protocol` and `recall_prefetch` as reference tracks. The corpus is 196 recorded Claude Code sessions, 40 signal and 156 distractors, with every arm ingesting identical bytes through its own write path.

## Why this section

Dynamic Benchmarks rather than Plain-Text: it runs an agent in a staged repository sandbox and grades the artifact it produces, which is closer to AppWorld than to a transcript or dialogue benchmark.

## Naming, flagged proactively

The plain-text section already lists **Agent Memory Benchmark (AMB)** from Vectorize. My project is `agent-memory-bench`, which is confusingly close. They are unrelated projects in different sections. Happy to adopt a disambiguating display title if you would prefer one.

## What I am not claiming

No performance numbers, no ranking, and no leaderboard placement. The project is in bring-up: no multi-product run has been published, and the leaderboard is empty by construction (`"official_run": null`) until a preregistered run produces a summary. The entry therefore carries no claim that would need a source under your editorial policy.

## Checks

- All three links resolve (200): site, code, and the Hugging Face dataset.
- Description is 24 words, under the 25-word cap.
- LF line endings preserved; one resource in this PR.
- Not already listed. `agent-memory-bench` does appear in the file today, but only as a substring of `vectorize-io/agent-memory-benchmark`.
