### PR TITLE
Recognise nested sub-items in check_star_order.py and state the sub-item convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ Grouped by year (newest first). **Bold** the title if reproducible code is publi
 
 ## Editorial policy
 
-- **Same rules for everyone.** Projects affiliated with the maintainers follow exactly the same ranking, format, and style rules as every other entry, and are marked with † in the README.
+- **Same rules for everyone.** Projects affiliated with the maintainers follow the same ranking, format, and style rules as every other entry, and are marked with † in the README.
+- **Drop-in replacements nest under their target.** A project whose purpose is to be an API-compatible replacement for a listed open-source product is written as an indented, unranked sub-item (`    - **[Name](...)**`) directly under that product rather than given its own star-ranked position. This applies regardless of who maintains it. `scripts/check_star_order.py` lists sub-items under their parent but excludes them from the star-order and 100-star-boundary checks.
 - **Stars are a signal, not a verdict.** Star ordering is an objective, CI-checked popularity signal — it is not a quality ranking or an endorsement.
 - **Claims name their source.** When an entry carries performance or benchmark claims, say where they come from: self-reported, paper-reported, or independently verified. Leaderboard placements use the compact form `#N, <Leaderboard> (<track>, YYYY-MM)` — e.g. `#6, Agent Memory Leaderboard (academic textual, 2026-08)` — so the attribution stays short enough to fit the 25-word description limit.
 - **Neutral statuses.** Projects that go inactive or whose claims are credibly disputed move to the Archival section with a neutral status label (Disputed / Inactive / Archived), links to the evidence, and the date the status was last checked — we document, we don't editorialize.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   - Open-source products are ordered by GitHub star count — an objective, CI-checked popularity signal, not a quality ranking or an endorsement. Products with fewer than 100 stars sit in a collapsed **Emerging projects** section and graduate into the main list once they cross that threshold.
   - **Bold** marks resources with reproducible code publicly available.
   - Descriptions are factual, not promotional (see the [contributing guide](CONTRIBUTING.md)).
-  - This list is maintained by [Bloo-Mind AI](https://www.bloo-mind.ai/) and the Ubiquitous AGI team at TeleAI. Entries affiliated with the maintainers are marked with † and follow exactly the same ranking, format, and style rules as every other entry.
+  - This list is maintained by [Bloo-Mind AI](https://www.bloo-mind.ai/) and the Ubiquitous AGI team at TeleAI. Entries affiliated with the maintainers are marked with † and follow the same ranking, format, and style rules as every other entry. One convention applies to all entries regardless of affiliation: an API-compatible drop-in replacement for a listed product is nested under that product as an unranked sub-item rather than given its own star-ranked position.
   - Projects that are inactive, archived, or whose claims are disputed move to the [Archival](#archival) subsection with a neutral status label, links to the evidence, and the date the status was last checked.
 
 </details>
@@ -110,7 +110,7 @@ _🤝 Contributions welcome! Feel free to open an issue or submit a pull request
 
 ### Open-Source
 
-_Ordered by the number of GitHub stars. Products with fewer than 100 stars continue the list inside the collapsed **Emerging projects** section below — they graduate into the main list once they cross that threshold._
+_Ordered by the number of GitHub stars. Products with fewer than 100 stars continue the list inside the collapsed **Emerging projects** section below — they graduate into the main list once they cross that threshold. An API-compatible drop-in replacement for a listed product appears as an unranked sub-item under that product._
 
 1. **[Claude-Mem (A Plug-in for Claude-Code)](https://claude-mem.ai/)**
      ![Star](https://img.shields.io/github/stars/thedotmack/claude-mem.svg?style=social&label=Star)
@@ -131,7 +131,7 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
         [[code](https://github.com/TeleAI-UAGI/TeleMem)]
         [[docs](https://teleai-uagi.github.io/telemem/)]
         [[paper](https://arxiv.org/abs/2601.06037)]
-        _API-compatible high-performance drop-in replacement for Mem0 (`import telemem as mem0`); listed as a sub-item of Mem0 rather than ranked by stars. Maintainer-affiliated._
+        _API-compatible high-performance drop-in replacement for Mem0 (`import telemem as mem0`); listed as an unranked sub-item of Mem0 per the drop-in replacement convention. Maintainer-affiliated._
 
 3. **[OpenViking](https://openviking.ai/)**
      ![Star](https://img.shields.io/github/stars/volcengine/OpenViking.svg?style=social&label=Star)

--- a/README.md
+++ b/README.md
@@ -314,17 +314,17 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/vostride/agent-qa)]
       _Open-source QA agent that retains persistent test memory to reuse prior runs and self-heal natural-language web and mobile tests._
 
-33. **[projectmem](https://projectmem.dev)**
+33. **[HMS (Holographic Memory System)](https://github.com/Shadow-Weave/HMS)**
+      ![Star](https://img.shields.io/github/stars/Shadow-Weave/HMS.svg?style=social&label=Star)
+      [[code](https://github.com/Shadow-Weave/HMS)]
+      _Long-term memory QA framework that wraps OpenAI clients with automatic recall and retain, PostgreSQL-backed, evaluated on LongMemEval._
+
+34. **[projectmem](https://projectmem.dev)**
       ![Star](https://img.shields.io/github/stars/riponcm/projectmem.svg?style=social&label=Star)
       [[code](https://github.com/riponcm/projectmem)]
       [[docs](https://projectmem.dev/guide)]
       [[paper](https://arxiv.org/abs/2606.12329)]
       _Local-first, event-sourced memory for AI coding agents: an append-only event log served via MCP, plus a pre-commit gate that warns before repeating a failed fix._
-
-34. **[HMS (Holographic Memory System)](https://github.com/Shadow-Weave/HMS)**
-      ![Star](https://img.shields.io/github/stars/Shadow-Weave/HMS.svg?style=social&label=Star)
-      [[code](https://github.com/Shadow-Weave/HMS)]
-      _Long-term memory QA framework that wraps OpenAI clients with automatic recall and retain, PostgreSQL-backed, evaluated on LongMemEval._
 
 35. **[deja](https://github.com/vshulcz/deja-vu)**
       ![Star](https://img.shields.io/github/stars/vshulcz/deja-vu.svg?style=social&label=Star)
@@ -412,23 +412,23 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
       [[code](https://github.com/Perseus-Computing-LLC/mimir)]
       _MCP-native persistent memory for agents as a single Rust binary — embedded SQLite with FTS5 + vector hybrid search, AES-256-GCM encryption at rest, fully local._
 
-50. **[Synap](https://maximem.ai)**
+50. **[causal-memory](https://github.com/JingxuanC/causal-memory)**
+      ![Star](https://img.shields.io/github/stars/JingxuanC/causal-memory.svg?style=social&label=Star)
+      [[code](https://github.com/JingxuanC/causal-memory)]
+      [[eval](https://github.com/JingxuanC/causal-memory/tree/main/docs/benchmarks)]
+      _Local-first agent memory in Rust: facts and typed decision→outcome causal edges (caused/enabled/prevented) on one SQLite store, with inhibitory spreading activation, MCP server, CLI, Python bindings._
+
+51. **[Synap](https://maximem.ai)**
       ![Star](https://img.shields.io/github/stars/maximem-ai/maximem_synap_sdk.svg?style=social&label=Star)
       [[code](https://github.com/maximem-ai/maximem_synap_sdk)]
       [[docs](https://docs.maximem.ai)]
       _Long-term memory layer that extracts facts, preferences, episodes, and temporal events from conversations; integrates with most major agent frameworks._
 
-51. **[Wenlan](https://wenlan.app/)**
+52. **[Wenlan](https://wenlan.app/)**
       ![Star](https://img.shields.io/github/stars/7xuanlu/wenlan.svg?style=social&label=Star)
       [[code](https://github.com/7xuanlu/wenlan)]
       [[docs](https://wenlan.app/docs)]
       _Local-first AI knowledge base and LLM wiki that distills agent work into source-cited pages and serves them to MCP clients._
-
-52. **[causal-memory](https://github.com/JingxuanC/causal-memory)**
-      ![Star](https://img.shields.io/github/stars/JingxuanC/causal-memory.svg?style=social&label=Star)
-      [[code](https://github.com/JingxuanC/causal-memory)]
-      [[eval](https://github.com/JingxuanC/causal-memory/tree/main/docs/benchmarks)]
-      _Local-first agent memory in Rust: facts and typed decision→outcome causal edges (caused/enabled/prevented) on one SQLite store, with inhibitory spreading activation, MCP server, CLI, Python bindings._
 
 53. **[RetainDB](https://retaindb.com)**
       ![Star](https://img.shields.io/github/stars/RetainDB/RetainDB.svg?style=social&label=Star)

--- a/scripts/check_star_order.py
+++ b/scripts/check_star_order.py
@@ -11,6 +11,12 @@ block: entries in the main list should have >= 100 stars and emerging entries
 < 100. A grace band (main >= 90 passes, emerging < 110 passes) stops projects
 hovering around 100 from flip-flopping between sections every week.
 
+Indented sub-items (`    - **[Name](...)**`, e.g. a drop-in replacement nested
+under the product it replaces) are unranked by convention: they are parsed and
+listed under their parent but excluded from both checks. A star badge that no
+numbered entry or sub-item claims is reported as an error so nothing can be
+skipped silently.
+
 Usage: GITHUB_TOKEN=... python3 scripts/check_star_order.py [README.md]
 
 To apply the ordering this script suggests, run its companion fixer:
@@ -25,6 +31,7 @@ import urllib.request
 
 BADGE_RE = re.compile(r"img\.shields\.io/github/stars/([\w.-]+/[\w.-]+)\.svg")
 ENTRY_RE = re.compile(r"^(\d+)\.\s+\*\*\[([^\]]+)\]")
+NESTED_RE = re.compile(r"^\s+-\s+\*\*\[([^\]]+)\]")
 SECTION_START = "### Open-Source"
 SECTION_END = "### Closed-Source"
 EMERGING_MARKER = "Emerging projects"
@@ -33,15 +40,23 @@ GRACE = 10  # main entries pass at >= THRESHOLD - GRACE, emerging at < THRESHOLD
 
 
 def parse_entries(readme_path):
-    """Return [(position, name, owner/repo, emerging)] for numbered open-source entries."""
+    """Return ([entries], [orphan badge lines]) for the open-source section.
+
+    Each entry is (position, name, owner/repo, emerging, parent): ranked entries
+    have parent=None; an indented sub-item carries its parent's position and the
+    parent's name. Orphans are (line number, owner/repo) for badges that no entry
+    line precedes.
+    """
     with open(readme_path, encoding="utf-8") as f:
         lines = f.readlines()
 
     entries = []
+    orphans = []
     in_section = False
     emerging = False
-    current = None  # (position, name) awaiting its badge
-    for line in lines:
+    current = None  # (position, name, parent) awaiting its badge
+    last_ranked = None  # (position, name) of the most recent numbered entry
+    for lineno, line in enumerate(lines, start=1):
         if SECTION_START in line:
             in_section = True
             continue
@@ -53,12 +68,20 @@ def parse_entries(readme_path):
             emerging = True
         m = ENTRY_RE.match(line)
         if m:
-            current = (int(m.group(1)), m.group(2))
+            last_ranked = (int(m.group(1)), m.group(2))
+            current = (*last_ranked, None)
+        else:
+            n = NESTED_RE.match(line)
+            if n and last_ranked:
+                current = (last_ranked[0], n.group(1), last_ranked[1])
         b = BADGE_RE.search(line)
-        if b and current:
-            entries.append((current[0], current[1], b.group(1), emerging))
-            current = None
-    return entries
+        if b:
+            if current:
+                entries.append((current[0], current[1], b.group(1), emerging, current[2]))
+                current = None
+            else:
+                orphans.append((lineno, b.group(1)))
+    return entries, orphans
 
 
 def fetch_stars(repo, token):
@@ -84,26 +107,37 @@ def main():
     if not token:
         sys.exit("GITHUB_TOKEN is required (rate limits)")
 
-    entries = parse_entries(readme)
+    entries, orphans = parse_entries(readme)
     if not entries:
         sys.exit("No open-source entries parsed — README format may have changed")
 
     starred = []
-    for pos, name, repo, emerging in entries:
+    for pos, name, repo, emerging, parent in entries:
         stars = fetch_stars(repo, token)
         if stars is not None:
-            starred.append((pos, name, repo, stars, emerging))
+            starred.append((pos, name, repo, stars, emerging, parent))
 
     print(f"{'#':>3}  {'stars':>7}  name")
-    for pos, name, repo, stars, emerging in starred:
+    for pos, name, repo, stars, emerging, parent in starred:
         tag = "  [emerging]" if emerging else ""
-        print(f"{pos:>3}  {stars:>7}  {name} ({repo}){tag}")
+        if parent:
+            print(f"{'':>3}  {stars:>7}    └ {name} ({repo})  [sub-item of {parent}, unranked]{tag}")
+        else:
+            print(f"{pos:>3}  {stars:>7}  {name} ({repo}){tag}")
 
     failed = False
 
+    if orphans:
+        failed = True
+        print("\nStar badges not attached to any recognised entry line (checker would skip them):")
+        for lineno, repo in orphans:
+            print(f"  line {lineno}: {repo}")
+
+    ranked = [e for e in starred if e[5] is None]
+
     inversions = [
         (a, b)
-        for a, b in zip(starred, starred[1:])
+        for a, b in zip(ranked, ranked[1:])
         if a[3] < b[3]
     ]
     if inversions:
@@ -112,27 +146,29 @@ def main():
         for a, b in inversions:
             print(f"  #{b[0]} {b[1]} ({b[3]} stars) should rank above #{a[0]} {a[1]} ({a[3]} stars)")
         print("\nSuggested order:")
-        for i, (_, name, repo, stars, _e) in enumerate(
-            sorted(starred, key=lambda e: -e[3]), start=1
+        for i, (_, name, repo, stars, _e, _p) in enumerate(
+            sorted(ranked, key=lambda e: -e[3]), start=1
         ):
             print(f"{i:>3}. {name} ({repo}, {stars} stars)")
 
     crossings = [
-        e for e in starred
+        e for e in ranked
         if (not e[4] and e[3] < THRESHOLD - GRACE)
         or (e[4] and e[3] >= THRESHOLD + GRACE)
     ]
     if crossings:
         failed = True
         print(f"\nWrong side of the {THRESHOLD}-star boundary (±{GRACE} grace):")
-        for pos, name, repo, stars, emerging in crossings:
+        for pos, name, repo, stars, emerging, _parent in crossings:
             direction = "move down into Emerging projects" if not emerging else "graduate into the main list"
             print(f"  #{pos} {name} ({stars} stars) should {direction}")
 
     if failed:
         sys.exit(1)
 
-    print("\nOK: list is ordered by star count and the emerging boundary holds.")
+    nested = len(starred) - len(ranked)
+    note = f" ({nested} unranked sub-item{'s' if nested != 1 else ''} listed, not ranked)" if nested else ""
+    print(f"\nOK: list is ordered by star count and the emerging boundary holds{note}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #100.

**Checker** (`scripts/check_star_order.py`)
- Parses indented sub-items (`    - **[Name](...)**`) and lists them under their parent as unranked, excluded from the star-order and 100-star-boundary checks.
- Any star badge that no numbered entry or sub-item claims is now reported and fails the run, so nothing can be skipped silently again.
- Verified against the live README: 96 ranked entries plus 1 sub-item (TeleMem under Mem0) are all accounted for; an orphan badge in a synthetic file fails as expected.

**Wording** (README.md, CONTRIBUTING.md)
- The † paragraph now states the drop-in replacement sub-item convention as part of the rule that applies to every entry, instead of "exactly the same ranking rules" sitting next to an entry that says it is not ranked.
- The Open-Source section note and the TeleMem entry reference the same convention.
- CONTRIBUTING.md gains a "Drop-in replacements nest under their target" bullet with the exact markup.

**Re-sort** (separate commit)
- The live run surfaced two small inversions from star drift (HMS/projectmem, causal-memory/Synap/Wenlan). Applied with `fix_star_order.py` so the star-order workflow passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
