### PR TITLE
Add ORANO Memory to Closed-Source products

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,10 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
 
 -  [Mem 2.0](https://get.mem.ai/)
    [[blog](https://get.mem.ai/blog)]
+-  [ORANO Memory](https://oranoai.com/mcp)
+   [[blog](https://oranoai.com/blog/personal-mcp-context-ai-agents.html)]
+   _Personal memory layer for consumer AI agents: the user's saved content (Reels, videos, articles, PDFs) is distilled into projects, memory facts, and embeddings that their own agent reads through a personal read-only MCP server._
+
 
 -  [M-Flow](https://m-flow.ai/)
 


### PR DESCRIPTION
Adds [ORANO Memory](https://oranoai.com/mcp) to **Products → Closed-Source**.

ORANO is a consumer app that builds a personal memory layer from the user's saved content (Reels, YouTube videos, articles, PDFs): structured projects, curated memory facts, a knowledge graph, and embeddings. The user's own agent (ChatGPT, Claude, Cursor, Ollama) reads this context through a personal read-only MCP server (bearer key, scope `orano:read`).

- Website: https://oranoai.com/
- MCP overview: https://oranoai.com/mcp
- iOS: https://apps.apple.com/us/app/orano-ai/id6791454509

Entry follows the existing Closed-Source format (name, optional link lines, italic description).