### PR TITLE
Add Wontopos (Tablet 2) to Closed-Source products

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,11 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
    [[blog](https://oranoai.com/blog/personal-mcp-context-ai-agents.html)]
    _Consumer app that distills saved Reels, videos, articles, and PDFs into projects and memory facts that the user's agent reads over a read-only MCP server._
 
+-  [Wontopos (Tablet 2)](https://wontopos.com/)
+   [[paper](https://arxiv.org/abs/2608.23920)]
+   [[eval](https://github.com/wontopos/beam1m-tablet-2)]
+   _Managed long-term memory API with no LLM in the retrieval path; paper-reported 95.2% mean recall@5 across 70 store-and-query language pairs._
+
 ### Archival
 
 _Projects that are inactive or whose claims have been disputed by third parties. Status labels link to the evidence and note when the status was last checked._

--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ _Ordered by the number of GitHub stars. Products with fewer than 100 stars conti
 -  [Wontopos (Tablet 2)](https://wontopos.com/)
    [[paper](https://arxiv.org/abs/2608.23920)]
    [[eval](https://github.com/wontopos/beam1m-tablet-2)]
-   _Managed long-term memory API with no LLM in the retrieval path; paper-reported 95.2% mean recall@5 across 70 store-and-query language pairs._
+   _Memory API, no language model in the retrieval path; paper-reported 95.7% LongMemEval-S and 95.2% recall@5 over 70 language pairs; BEAM-1M 67.5% with harness and per-question records published._
 
 ### Archival
 


### PR DESCRIPTION
## What does this PR add or change?

Add Wontopos (Tablet 2) to Products -> Closed-Source.

Managed long-term memory API for LLM agents. Its retrieval path contains no lexical matching, no keyword scoring and no language model of its own, which is what the cross-lingual result rests on.

On the numbers, per "claims name their source": all three are marked paper-reported, and the description separates them by what is checkable. BEAM-1M carries the harness, the scoring scripts and the per-question records; the LongMemEval-S directory holds the run records only. I did not want one "harness published" to imply more coverage than that.

Links are labelled `paper` and `eval`. I used `eval` rather than `benchmark` per CONTRIBUTING.md: the harness and records are public, but the results are still self-run.

## Checklist

- [x] Not already listed (searched the README, including alternative names)
- [x] Links point to primary sources and resolve
- [x] Entry follows the format in CONTRIBUTING.md (one-line factual description, correct section/year)
- [x] Open-source products: placed at the position matching current GitHub star count - n/a, closed-source entry appended to the end of its section
- [x] File keeps LF line endings